### PR TITLE
Support extra vars of Ansible.

### DIFF
--- a/{{cookiecutter.role_project_name}}/.travis.yml
+++ b/{{cookiecutter.role_project_name}}/.travis.yml
@@ -66,7 +66,7 @@ install:
 script:
   # Basic role syntax check
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
-  - ansible-playbook tests/test.yml -i tests/inventory -l ${TARGET} -vvvv
+  - ansible-playbook tests/test.yml -i tests/inventory -l ${TARGET} --extra-vars="${EXTRA_VARS}" -vvvv
   - bundle exec rake spec SPEC_TARGET=${TARGET}
 
 notifications:


### PR DESCRIPTION
Environment variable 'EXTRA_VARS' can be used to pass arbitrary
variables.
